### PR TITLE
Fix process.exit.

### DIFF
--- a/app.js
+++ b/app.js
@@ -50,7 +50,7 @@ class vlc {
       this._setupStatusRequests()
 
       this.process.on('close', (code) => {
-        process.exit()
+        this.process.exit()
       })
 
       this.process.stderr.on('data', (data) => {


### PR DESCRIPTION
FIX process.exit() close the whole application instead of vlc child process.